### PR TITLE
Fix chaincode package release

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,8 +6,6 @@ on:
     tags: [ v* ]
   pull_request:
     branches: [ main ]
-  release:
-    types: [ published ]
 
 jobs:
 
@@ -39,10 +37,12 @@ jobs:
         chaincode-image: ghcr.io/hyperledgendary/conga-nft-contract
         chaincode-tag: $GITHUB_SHA
     - name: Rename package
-      run: mv conga-nft-contract.tgz conga-nft-contract-${GITHUB_REF_NAME}.tgz
-      if: github.event_name == 'release'
+      run: mv conga-nft-contract.tgz conga-nft-contract-${CHAINCODE_VERSION}.tgz
+      if: startsWith(github.ref, 'refs/tags/v')
+      env:
+        CHAINCODE_VERSION: ${{ github.ref_name }}
     - name: Release package
       uses: softprops/action-gh-release@v1
-      if: github.event_name == 'release'
+      if: startsWith(github.ref, 'refs/tags/v')
       with:
-        files: conga-nft-contract-${GITHUB_REF_NAME}.tgz
+        files: conga-nft-contract-${{ github.ref_name }}.tgz


### PR DESCRIPTION
Update condition to check GitHub ref instead of release event which did not seem to have the ref name available

Signed-off-by: James Taylor <jamest@uk.ibm.com>